### PR TITLE
removed redundant dotenv package from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "cross-spawn": "4.0.2",
     "css-loader": "0.26.0",
     "detect-port": "1.0.1",
-    "dotenv": "2.0.0",
     "eslint": "3.8.1",
     "eslint-config-react-app": "^0.5.0",
     "eslint-loader": "1.6.0",


### PR DESCRIPTION
i think we only need this package once unless i'm overlooking some edge case here :)