### PR TITLE
Updated to jest version compatible with testMatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "gzip-size": "3.0.0",
     "html-webpack-plugin": "2.24.0",
     "http-proxy-middleware": "0.17.2",
-    "jest": "18.1.0",
+    "jest": "19.0.1",
     "json-loader": "0.5.4",
     "object-assign": "4.1.0",
     "path-exists": "2.1.0",


### PR DESCRIPTION
`testMatch` is incompatible with jest 18.1.0 and was causing errors thrown when running `npm test`:

```
Error: Unknown config option "testMatch" with value "<rootDir>/src/**/__tests__/**/*.js?(x),<rootDir>/src/**/?(*.)(spec|test).js?(x)". This is either a typing error or a user mistake and fixing it will remove this message.
```

This updates to use 19.0.1 per https://facebook.github.io/jest/docs/configuration.html#testmatch-array-string

Breaking changes between 18.1.0 and 19.0.1 don't affect current tests.