### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@ This box comes with everything you need to start using smart contracts from a re
     npm install -g truffle
     ```
 
-2. Download the box. This also takes care of installing the necessary dependencies.
+2. Create a new directory for your project and download the box. This also takes care of installing the necessary dependencies.
     ```javascript
+    mkdir my_project
+    cd my_project
     truffle unbox react
     ```
 


### PR DESCRIPTION
Add instructions to run `truffle unbox` in a project directory.

`truffle unbox` will unbox the box in the working directory, which may not be what the user expects to happen. 