### PR TITLE
Update getWeb3.js corrected wrong port

### DIFF
--- a/src/utils/getWeb3.js
+++ b/src/utils/getWeb3.js
@@ -21,7 +21,7 @@ let getWeb3 = new Promise(function(resolve, reject) {
     } else {
       // Fallback to localhost if no web3 injection. We've configured this to
       // use the development console's port by default.
-      var provider = new Web3.providers.HttpProvider('http://127.0.0.1:9545')
+      var provider = new Web3.providers.HttpProvider('http://127.0.0.1:8545')
 
       web3 = new Web3(provider)
 


### PR DESCRIPTION
The default port for the web3 provider is 9545 instead of 8545 (testrpc and geth)