### PR TITLE
Update deprecated constructor to use "constructor"

### DIFF
--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.2;
+pragma solidity ^0.4.22;
 
 contract Migrations {
   address public owner;
@@ -8,7 +8,7 @@ contract Migrations {
     if (msg.sender == owner) _;
   }
 
-  function Migrations() public {
+  constructor() public {
     owner = msg.sender;
   }
 


### PR DESCRIPTION
Using the "function contractName" is being deprecated. Changing to "constructor". Updating version to Solidity 0.4.22 for backward compilation compatibility.