### PR TITLE
Use constructor in Migrations.sol:11:3:

### DIFF
--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -8,7 +8,7 @@ contract Migrations {
     if (msg.sender == owner) _;
   }
 
-  function Migrations() public {
+  constructor() public {
     owner = msg.sender;
   }
 


### PR DESCRIPTION
This pull request solves issue https://github.com/truffle-box/react-box/issues/58 which is about compilation failure due to this deprecation warning:
```
Warning: Defining constructors as functions with the same name as the contract is deprecated. Use "constructor(...) { ... }" instead.
  function Migrations() public {
  ^ (Relevant source part starts here and spans across multiple lines).
```

## Solution
Fix Migrations.sol:11:3: 
from this
```
function Migrations() public {
```
to this
```
constructor() public {
```
