### PR TITLE
Fix race condition between setState and contract instantiation in App.js

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -23,19 +23,18 @@ class App extends Component {
 
     getWeb3
     .then(results => {
-      this.setState({
-        web3: results.web3
-      })
-
+      const { web3 } = results;
       // Instantiate contract once web3 provided.
-      this.instantiateContract()
+      this.instantiateContract(web3)
+
+      this.setState({ web3 })
     })
     .catch(() => {
       console.log('Error finding web3.')
     })
   }
 
-  instantiateContract() {
+  instantiateContract(web3) {
     /*
      * SMART CONTRACT EXAMPLE
      *
@@ -45,13 +44,13 @@ class App extends Component {
 
     const contract = require('truffle-contract')
     const simpleStorage = contract(SimpleStorageContract)
-    simpleStorage.setProvider(this.state.web3.currentProvider)
+    simpleStorage.setProvider(web3.currentProvider)
 
     // Declaring this for later so we can chain functions on SimpleStorage.
     var simpleStorageInstance
 
     // Get accounts.
-    this.state.web3.eth.getAccounts((error, accounts) => {
+    web3.eth.getAccounts((error, accounts) => {
       simpleStorage.deployed().then((instance) => {
         simpleStorageInstance = instance
 


### PR DESCRIPTION
React `setState` is asynchronous and may batch multiple calls into one state update. This leads to a possible race condition where `instantiateContract` can be called before the state has been updated with the web3 instance. This can lead to unexpected behavior.

By passing the `web3` directly we can ensure that this does not happen.