### PR TITLE
Update truffle-contract dependency version

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,7 @@
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
     "react-scripts": "1.1.4",
-    "truffle-contract": "^4.0.0-next.0",
+    "truffle-contract": "^3.0.6",
     "web3": "^1.0.0-beta.35"
   },
   "scripts": {


### PR DESCRIPTION
(disclaimer: I am utterly clueless about node and truffle at large, just starting out)

While trying to get started with the truffle react box. I performed the following steps:
```
$ truffle unbox react
$ truffle migrate
$ cd client && npm run start
```

This lead to the following error:
```
./node_modules/truffle-contract/lib/reformat.js
Module not found: Can't resolve 'bignumber.js' in '/Users/me/code/dapps/mdhp/client/node_modules/truffle-contract/lib'
```

I went over to the trufflesuite repo and noticed that the current version of truffle-contract is `3.0.6`. I then updated package.json to use `^3.0.6` for the `truffle-contract` version and ran `npm install` and after that running `npm run start` is successful. 

Someone with a better understanding than me should audit this change and make sure I'm not breaking something else, however this is fixing the issue for me.