### PR TITLE
Enable user to approve access if privacy mode is on

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -4306,11 +4306,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4323,15 +4325,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4434,7 +4439,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4444,6 +4450,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4456,17 +4463,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4483,6 +4493,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4555,7 +4566,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4565,6 +4577,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4670,6 +4683,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/client/src/utils/getWeb3.js
+++ b/client/src/utils/getWeb3.js
@@ -1,53 +1,38 @@
 import Web3 from "web3";
-
+ 
 const getWeb3 = () =>
   new Promise((resolve, reject) => {
     // Wait for loading completion to avoid race conditions with web3 injection timing.
     window.addEventListener("load", async () => {
       // Modern dapp browsers...
       if (window.ethereum) {
-        const { ethereum } = window;
-
-        const web3 = new Web3(ethereum);
+        const web3 = new Web3(window.ethereum);
         try {
           // Request account access if needed
-          await ethereum.enable();
+          await window.ethereum.enable();
           // Acccounts now exposed
           resolve(web3);
         } catch (error) {
-          alert(error);
+          reject(error);
         }
       }
       // Legacy dapp browsers...
       else if (window.web3) {
-        let web3 = window.web3;
-
-        // Checking if Web3 has been injected by the browser (Mist/MetaMask).
-        const alreadyInjected = typeof web3 !== "undefined";
-
-        if (alreadyInjected) {
-          // Use Mist/MetaMask's provider.
-          web3 = new Web3(web3.currentProvider);
-          console.log("Injected web3 detected.");
-          resolve(web3);
-        } else {
-          // Fallback to localhost if no web3 injection. We've configured this to
-          // use the development console's port by default.
-          const provider = new Web3.providers.HttpProvider(
-            "http://127.0.0.1:9545"
-          );
-          web3 = new Web3(provider);
-          console.log("No web3 instance injected, using Local web3.");
-          resolve(web3);
-        }
+        // Use Mist/MetaMask's provider.
+        web3 = new Web3(web3.currentProvider);
+        console.log("Injected web3 detected.");
+        resolve(web3);
       }
-      // Non-dapp browsers...
+      // Fallback to localhost; use dev console port by default...
       else {
-        console.log(
-          "Non-Ethereum browser detected. You should consider trying MetaMask!"
+        const provider = new Web3.providers.HttpProvider(
+          "http://127.0.0.1:9545"
         );
+        web3 = new Web3(provider);
+        console.log("No web3 instance injected, using Local web3.");
+        resolve(web3);
       }
     });
   });
-
+ 
 export default getWeb3;

--- a/client/src/utils/getWeb3.js
+++ b/client/src/utils/getWeb3.js
@@ -3,26 +3,49 @@ import Web3 from "web3";
 const getWeb3 = () =>
   new Promise((resolve, reject) => {
     // Wait for loading completion to avoid race conditions with web3 injection timing.
-    window.addEventListener("load", () => {
-      let web3 = window.web3;
+    window.addEventListener("load", async () => {
+      // Modern dapp browsers...
+      if (window.ethereum) {
+        const { ethereum } = window;
 
-      // Checking if Web3 has been injected by the browser (Mist/MetaMask).
-      const alreadyInjected = typeof web3 !== "undefined";
+        const web3 = new Web3(ethereum);
+        try {
+          // Request account access if needed
+          await ethereum.enable();
+          // Acccounts now exposed
+          resolve(web3);
+        } catch (error) {
+          alert(error);
+        }
+      }
+      // Legacy dapp browsers...
+      else if (window.web3) {
+        let web3 = window.web3;
 
-      if (alreadyInjected) {
-        // Use Mist/MetaMask's provider.
-        web3 = new Web3(web3.currentProvider);
-        console.log("Injected web3 detected.");
-        resolve(web3);
-      } else {
-        // Fallback to localhost if no web3 injection. We've configured this to
-        // use the development console's port by default.
-        const provider = new Web3.providers.HttpProvider(
-          "http://127.0.0.1:9545"
+        // Checking if Web3 has been injected by the browser (Mist/MetaMask).
+        const alreadyInjected = typeof web3 !== "undefined";
+
+        if (alreadyInjected) {
+          // Use Mist/MetaMask's provider.
+          web3 = new Web3(web3.currentProvider);
+          console.log("Injected web3 detected.");
+          resolve(web3);
+        } else {
+          // Fallback to localhost if no web3 injection. We've configured this to
+          // use the development console's port by default.
+          const provider = new Web3.providers.HttpProvider(
+            "http://127.0.0.1:9545"
+          );
+          web3 = new Web3(provider);
+          console.log("No web3 instance injected, using Local web3.");
+          resolve(web3);
+        }
+      }
+      // Non-dapp browsers...
+      else {
+        console.log(
+          "Non-Ethereum browser detected. You should consider trying MetaMask!"
         );
-        web3 = new Web3(provider);
-        console.log("No web3 instance injected, using Local web3.");
-        resolve(web3);
       }
     });
   });


### PR DESCRIPTION
Fixes #74 

Add new MetaMask ethereum.enable() method to approve accounts access if user has turned on new privacy option in Metamask (EIP-1102). 

Tested with MetaMask 4.16.0

Reference: https://medium.com/metamask/https-medium-com-metamask-breaking-change-injecting-web3-7722797916a8?fbclid=IwAR3ZdRRUyvQ7AMvn3BaVC0_XIoGreK5_LguZJuiTMVzCbWKja0PAjhH8kbw