### PR TITLE
add support for EIP-1102

### DIFF
--- a/client/src/utils/getWeb3.js
+++ b/client/src/utils/getWeb3.js
@@ -1,30 +1,38 @@
 import Web3 from "web3";
-
+ 
 const getWeb3 = () =>
   new Promise((resolve, reject) => {
     // Wait for loading completion to avoid race conditions with web3 injection timing.
-    window.addEventListener("load", () => {
-      let web3 = window.web3;
-
-      // Checking if Web3 has been injected by the browser (Mist/MetaMask).
-      const alreadyInjected = typeof web3 !== "undefined";
-
-      if (alreadyInjected) {
+    window.addEventListener("load", async () => {
+      // Modern dapp browsers...
+      if (window.ethereum) {
+        const web3 = new Web3(window.ethereum);
+        try {
+          // Request account access if needed
+          await window.ethereum.enable();
+          // Acccounts now exposed
+          resolve(web3);
+        } catch (error) {
+          reject(error);
+        }
+      }
+      // Legacy dapp browsers...
+      else if (window.web3) {
         // Use Mist/MetaMask's provider.
-        web3 = new Web3(web3.currentProvider);
+        const web3 = window.web3;
         console.log("Injected web3 detected.");
         resolve(web3);
-      } else {
-        // Fallback to localhost if no web3 injection. We've configured this to
-        // use the development console's port by default.
+      }
+      // Fallback to localhost; use dev console port by default...
+      else {
         const provider = new Web3.providers.HttpProvider(
           "http://127.0.0.1:9545"
         );
-        web3 = new Web3(provider);
+        const web3 = new Web3(provider);
         console.log("No web3 instance injected, using Local web3.");
         resolve(web3);
       }
     });
   });
-
+ 
 export default getWeb3;


### PR DESCRIPTION
Fixes #74

Add new MetaMask ethereum.enable() method to approve accounts access if user has turned on new privacy option in Metamask (EIP-1102).

Tested with MetaMask 4.16.0

Reference: https://medium.com/metamask/https-medium-com-metamask-breaking-change-injecting-web3-7722797916a8?fbclid=IwAR3ZdRRUyvQ7AMvn3BaVC0_XIoGreK5_LguZJuiTMVzCbWKja0PAjhH8kbw