### PR TITLE
Remove old config

### DIFF
--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 
 contract Migrations {
   address public owner;

--- a/contracts/SimpleStorage.sol
+++ b/contracts/SimpleStorage.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 
 contract SimpleStorage {
   uint storedData;

--- a/test/TestSimpleStorage.sol
+++ b/test/TestSimpleStorage.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 
 import "truffle/Assert.sol";
 import "truffle/DeployedAddresses.sol";

--- a/truffle.js
+++ b/truffle.js
@@ -1,7 +1,0 @@
-const path = require("path");
-
-module.exports = {
-  // See <http://truffleframework.com/docs/advanced/configuration>
-  // to customize your Truffle configuration!
-  contracts_build_directory: path.join(__dirname, "client/src/contracts")
-};


### PR DESCRIPTION
This removes `truffle.js` in favor of using `truffle-config.js` in the future. It also updates the solidity version used in this project to `^0.5.0`.