### PR TITLE
Fix problem with getWeb3() returned API consistency

### DIFF
--- a/client/src/utils/getWeb3.js
+++ b/client/src/utils/getWeb3.js
@@ -17,9 +17,10 @@ const getWeb3 = () =>
         }
       }
       // Legacy dapp browsers...
-      else if (window.web3) {
+      else if (Web3.givenProvider) {
         // Use Mist/MetaMask's provider.
-        const web3 = window.web3;
+        const provider = Web3.givenProvider;
+        const web3 = new Web3(provider);
         console.log("Injected web3 detected.");
         resolve(web3);
       }


### PR DESCRIPTION
window.web3 does not always provide a consistent API. I've had several issues with this on mobile dApp browsers, since it was returning an older version of web3 with different API. The solution is to use `new Web3(Web3.currentProvider)` instead, where Web3 is the one imported from the dependencies, _not the one in the window_.