### PR TITLE
Fix: Remove transitive node-gyp dependency

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -5352,19 +5352,23 @@
       }
     },
     "eth-lib": {
-      "version": "0.1.27",
-      "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.27.tgz",
-      "integrity": "sha512-B8czsfkJYzn2UIEMwjc7Mbj+Cy72V+/OXH/tb44LV8jhrjizQJJ325xMOMyk3+ETa6r6oi0jsUY14+om8mQMWA==",
+      "version": "0.1.29",
+      "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.29.tgz",
+      "integrity": "sha512-bfttrr3/7gG4E02HoWTDUcDDslN003OlOoBxk9virpAZQ1ja/jDgwkWB8QfJF7ojuEowrqy+lzp9VcJG7/k5bQ==",
       "requires": {
         "bn.js": "^4.11.6",
         "elliptic": "^6.4.0",
-        "keccakjs": "^0.2.1",
         "nano-json-stream-parser": "^0.1.2",
         "servify": "^0.1.12",
         "ws": "^3.0.0",
         "xhr-request-promise": "^0.1.2"
       },
       "dependencies": {
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+        },
         "ws": {
           "version": "3.3.3",
           "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -4256,13 +4256,12 @@ eth-lib@0.2.7:
     xhr-request-promise "^0.1.2"
 
 eth-lib@^0.1.26:
-  version "0.1.27"
-  resolved "https://registry.yarnpkg.com/eth-lib/-/eth-lib-0.1.27.tgz#f0b0fd144f865d2d6bf8257a40004f2e75ca1dd6"
-  integrity sha512-B8czsfkJYzn2UIEMwjc7Mbj+Cy72V+/OXH/tb44LV8jhrjizQJJ325xMOMyk3+ETa6r6oi0jsUY14+om8mQMWA==
+  version "0.1.29"
+  resolved "https://registry.yarnpkg.com/eth-lib/-/eth-lib-0.1.29.tgz#0c11f5060d42da9f931eab6199084734f4dbd1d9"
+  integrity sha512-bfttrr3/7gG4E02HoWTDUcDDslN003OlOoBxk9virpAZQ1ja/jDgwkWB8QfJF7ojuEowrqy+lzp9VcJG7/k5bQ==
   dependencies:
     bn.js "^4.11.6"
     elliptic "^6.4.0"
-    keccakjs "^0.2.1"
     nano-json-stream-parser "^0.1.2"
     servify "^0.1.12"
     ws "^3.0.0"


### PR DESCRIPTION
`keccakjs` relies on `node-gyp` which makes [bad things happen](https://github.com/truffle-box/react-box/issues/125).

Resolves #125 .