### PR TITLE
Update deprecated ethereum command

### DIFF
--- a/client/src/getWeb3.js
+++ b/client/src/getWeb3.js
@@ -9,7 +9,7 @@ const getWeb3 = () =>
         const web3 = new Web3(window.ethereum);
         try {
           // Request account access if needed
-          await window.ethereum.enable();
+          await window.ethereum.request({ method: 'eth_requestAccounts' });
           // Accounts now exposed
           resolve(web3);
         } catch (error) {


### PR DESCRIPTION
As suggested https://github.com/truffle-box/react-box/issues/165 is the updated call to ethereum.enable(). Confirmed it is working as expected locally. 