### PR TITLE
Update truffle-config.js to include more default options

### DIFF
--- a/truffle-config.js
+++ b/truffle-config.js
@@ -5,8 +5,10 @@ module.exports = {
   // to customize your Truffle configuration!
   contracts_build_directory: path.join(__dirname, "client/src/contracts"),
   networks: {
-    develop: {
-      port: 8545
+    development: {
+      port: 8545,
+      host: "127.0.0.1",
+      network_id: "*"
     }
   }
 };


### PR DESCRIPTION
Update truffle-config.js to include the host and network_id options which are required to be passed for `truffle migrate` command to work when using default gananche cli.